### PR TITLE
cmake: adapt library install dir according to the host OS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,8 @@ project(buffer)
 if (${CMAKE_SYSTEM_NAME} MATCHES "Windows")
   set(LIBBUFFER_LIB_DIR "bin")
 else()
-  set(LIBBUFFER_LIB_DIR "lib")
+  include(GNUInstallDirs)
+  set(LIBBUFFER_LIB_DIR ${CMAKE_INSTALL_LIBDIR})
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,12 @@
 project(buffer)
 
+if (${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+  set(LIBBUFFER_LIB_DIR "bin")
+else()
+  set(LIBBUFFER_LIB_DIR "lib")
+endif()
+
+
 # Create a shared library
 file(GLOB SOURCES src/*.cpp src/*.c)
 add_library(${PROJECT_NAME} SHARED ${SOURCES})
@@ -14,8 +21,8 @@ target_link_libraries(${PROJECT_NAME} PUBLIC ${LIB_DEPENDS})
 # What to install
 install(TARGETS ${PROJECT_NAME}
   RUNTIME DESTINATION bin
-  LIBRARY DESTINATION bin
-  ARCHIVE DESTINATION bin
+  LIBRARY DESTINATION ${LIBBUFFER_LIB_DIR}
+  ARCHIVE DESTINATION ${LIBBUFFER_LIB_DIR}
 )
 install(
   DIRECTORY include/makestuff DESTINATION include


### PR DESCRIPTION
By default, and for a windows target, libraries are usually installed in bin directory. But for linux target OS the usual place is lib.
This PR add an cmake variable pointing to bin or lib according to the host system, and used in the install rule.
